### PR TITLE
fix i18n problem

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -37,10 +37,12 @@ export const wrapPageElement = ({
   },
 }) => {
   return (
-    <Layout>
-      <Router path={uri} />
-      <I18nWrapper locale={locale}>{element}</I18nWrapper>
-    </Layout>
+    <I18nWrapper locale={locale}>
+      <Layout>
+        <Router path={uri} />
+        {element}
+      </Layout>
+    </I18nWrapper>
   );
 };
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -15,10 +15,10 @@ export const wrapPageElement = ({
   },
 }) => {
   return (
-    <Layout>
-      <I18nWrapper locale={locale} ssr>
+    <I18nWrapper locale={locale} ssr>
+      <Layout>
         {element}
-      </I18nWrapper>
-    </Layout>
+      </Layout>
+    </I18nWrapper>
   );
 };


### PR DESCRIPTION
the problem is due to the i18nWrapper is not the parent of `Layout`, and so when the language changes the `Layout` component is not re-rendered